### PR TITLE
chore: handle imports organization in Eclipse and IntelliJ

### DIFF
--- a/java/README.adoc
+++ b/java/README.adoc
@@ -39,7 +39,7 @@ First, you need to install the http://checkstyle.org/eclipse-cs/#!/[CheckStyle P
 You'll see a list of two already existing configurations (Google and Sun):
 
 * Click on `New` and in the new window select `External Configuration File`.
-* Put the name [red]`Yseop Code Checks` (the name is important) in the `Name` box, then click on `Browse`, and select [red]`codequality/java/codeChecks/Yseop_Code_Checks.xml`.
+* Put the name [red]`Yseop Code Checks` (the name is important) in the `Name` box, then click on `Browse`, and select [red]`{PATH_TO_CODEQUALITY_REPOSITORY}/java/codeChecks/Yseop_Code_Checks.xml`.
 * Then click on `Set as default`, and finally, `Apply and Close`.
 
 Eclipse will prompt you about rebuilding the projects, select `Yes`.
@@ -53,7 +53,7 @@ You should now see the code style 'errors' highlighted in your editor.
 To try and fix these 'errors', you need to add a code formatter to Eclipse:
 
 * Go to `Window -> Preferences -> Java -> Code Style -> Formatter`.
-* Click on `Import`, and select [red]`codequality/java/codeFormatter/Yseop_Code_Formatter.xml`.
+* Click on `Import`, and select [red]`{PATH_TO_CODEQUALITY_REPOSITORY}/java/codeFormatter/Yseop_Code_Formatter.xml`.
 * Apply and Close.
 
 To make sure the formatter will be used by each of your project:
@@ -84,14 +84,10 @@ To make sure the save actions will be the same for each of your projects:
 
 === Imports
 
-Imports organization is also important for a standardized code style:
+Imports organization is also important for a standardized code style. The rule is to sort imports alphabetically.
 
 * Go to `Window -> Preferences -> Java -> Code Style -> Organize Imports`.
-* Rearrange the import in alphabetical order, for example :
-** `com`
-** `java`
-** `javax`
-** `org`
+* Click on `Import…` and select the file `{PATH_TO_CODEQUALITY_REPOSITORY}/java/importsOrder/Yseop_Imports_Order.importorder`.
 * Make sur the `Number of imports needed for .\*` and `Number of static imports needed for .*` are set to 99.
 * Apply and close.
 
@@ -142,7 +138,7 @@ Install the Eclipse code Formatter plugin from IntelliJ settings:
 
 - Check `Optimize imports`,
 
-- Check `Import order -> Manual configuration` and leave the field blank to force alphabetical sorting,
+- Check `Import order -> From file` and select `{PATH_TO_CODEQUALITY_REPOSITORY}/java/importsOrder/Yseop_Imports_Order.importorder`,
 
 - Click OK.
 
@@ -169,4 +165,3 @@ To be sure not to forget to format your code, you can set a `Save Actions`, a se
 - `Remove explicit generic type for diamond` 
 - and `Remove unnecessary semicolon` boxes.
 * Click Ok.
-

--- a/java/importsOrder/Yseop_Imports_Order.importorder
+++ b/java/importsOrder/Yseop_Imports_Order.importorder
@@ -1,8 +1,10 @@
 #Organize Import Order
 #Fri Nov 22 08:38:33 CET 2019
-5=org
-4=lombok
-3=javax
-2=java
-1=io
-0=com
+7=org
+6=net
+5=lombok
+4=javax
+3=java
+2=io
+1=com
+0=ch

--- a/java/importsOrder/Yseop_Imports_Order.importorder
+++ b/java/importsOrder/Yseop_Imports_Order.importorder
@@ -1,0 +1,8 @@
+#Organize Import Order
+#Fri Nov 22 08:38:33 CET 2019
+5=org
+4=lombok
+3=javax
+2=java
+1=io
+0=com

--- a/java/src/main/java/template/Comments.java
+++ b/java/src/main/java/template/Comments.java
@@ -46,12 +46,12 @@ interface Example {
      * </pre>
      *
      * Descriptions of parameters and return values are best appended at end of the javadoc comment.
-     *
-     * @param a The first parameter. For an optimum result, this should be an odd number between 0 and 100.
-     * @param b The second parameter.
-     * @return The result of the foo operation, usually within 0 and 1000.
+     * 
+     * @param  first  The first parameter. For an optimum result, this should be an odd number between 0 and 100.
+     * @param  second The second parameter.
+     * @return        The result of the foo operation, usually within 0 and 1000.
      */
-    int foo(int a, int b);
+    int foo(int first, int second);
 }
 
 class Test {

--- a/java/src/main/java/template/LineWrapping.java
+++ b/java/src/main/java/template/LineWrapping.java
@@ -118,6 +118,7 @@ public class LineWrapping {
     }
 
     enum ExampleColor {
+
         GREEN(0, 255, 0),
         RED(255, 0, 0);
 


### PR DESCRIPTION
Imports organization was still weird between Eclipse and IntelliJ.
This PR tries to solve the problem:
- add a file with imports order,
- update the related chapter in the documentation.

@ogenvo-yseop @apaliard-yseop Can you try to update your IDE settings and see if the sorting of imports is the same in Eclipse and IJ (I ran a few tests on my side, it looks ok).

Note: the file with imports order has to be maintained if new root packages are used in our projects. Feel free to add entries in it.