### PR TITLE
docs: remove eclipse from intellij installation

### DIFF
--- a/java/README.adoc
+++ b/java/README.adoc
@@ -123,8 +123,6 @@ To match Eclipse code formatter configuration, we will use the IntelliJ plugin l
 
 . Tries to configure the IntelliJ standard code formatter to match the Eclipse code formatter settings weren't successfull: there were always differences between both formatters (especially in Javadoc, empty blocks and white lines).
 
-. *Since the plugin will use the Eclipse formatter, you need to install Eclipse first and configure its code formatter as detailled in* link:#_eclipse[Eclipse]
-
 
 ==== Installation
 


### PR DESCRIPTION
After doing the installation with Antoine, we don't have to install Eclipse when only using intellij. This part is actually more confusing since i tried to install and configure 2 formatters.