### PR TITLE
feat: allow disabling format with markers @formatter:off/@formatter:on

### DIFF
--- a/java/codeFormatter/Yseop_Code_Formatter.xml
+++ b/java/codeFormatter/Yseop_Code_Formatter.xml
@@ -75,7 +75,7 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.comment.align_tags_descriptions_grouped" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="130"/>
-<setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="true"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation" value="do not insert"/>


### PR DESCRIPTION
In the file Yseop_Code_Formatter.xml, the following fields were set:
```
<setting id="org.eclipse.jdt.core.formatter.disabling_tag" value="@formatter:off"/>
<setting id="org.eclipse.jdt.core.formatter.enabling_tag" value="@formatter:on"/>
```

but the feature was disabled by setting the field `org.eclipse.jdt.core.formatter.use_on_off_tags` to `false`.

I think this feature may be useful in some comments that need a particular formatting (hen we want to keep spaces and tabs, for eg.).

If you disagree, I'll be ok to discuss and won't insist that much :-) I currently need it in one of my comment, but maybe this comment won't be kept because the feature is temporary. Anyway, I still think that this possibility would be nice!