### PR TITLE
docs(bash): “functions and snippets” section; “curl with status”

### DIFF
--- a/bash/README.adoc
+++ b/bash/README.adoc
@@ -2023,6 +2023,35 @@ Make sure `run-tests.sh` is executable (`chmod u+x`).
 ====
 
 
+== Useful functions and snippets
+
+=== Curl with status, AKA “fail with body”
+
+While using curl might seem simple, it’s often hard to get the correct behavior when juggling with options like `--fail`, `--silent` and `--show-error`: you can end up with…
+
+* the shell script not caring about an HTTP error (due to `curl` exiting with a misleading status), or
+* `curl` not printing anything in case of failures:
+** not telling you what the body was,
+** nor what HTTP status it got.
+
+Consider using the function of the following GitHub gist to make logs more developer-friendly: +
+https://gist.github.com/mminot-yseop/c02003e73c06517a7fd053f08e672018
+
+.Typical usage
+====
+unset -v args
+args=(
+    'https://acp.yseop-cloud.com/api/v1/platforms'
+    --header 'Accept: application/json'
+    --basic
+    --user "${ACP_USR:?}:${ACP_PSW:?}"
+    -sS # = “--silent” + “--show-error”
+)
+
+curl_fail_with_body "${args[@]}"
+====
+
+
 == Further reading and watching
 
 * https://drive.google.com/file/d/1oSxE6qZXBAzRKEaVJnXdufy7jYvGaYf4/view?usp=sharing[Internal technical presentation (French).]

--- a/bash/README.adoc
+++ b/bash/README.adoc
@@ -2027,7 +2027,7 @@ Make sure `run-tests.sh` is executable (`chmod u+x`).
 
 === Curl with status, AKA “fail with body”
 
-While using curl might seem simple, it’s often hard to get the correct behavior when juggling with options like `--fail`, `--silent` and `--show-error`: you can end up with…
+While using `curl` might seem simple, it’s often hard to get the correct behavior when juggling with options like `--fail`, `--silent` and `--show-error`: you can end up with…
 
 * the shell script not caring about an HTTP error (due to `curl` exiting with a misleading status), or
 * `curl` not printing anything in case of failures:
@@ -2039,6 +2039,8 @@ https://gist.github.com/mminot-yseop/c02003e73c06517a7fd053f08e672018
 
 .Typical usage
 ====
+[source, bash]
+----
 unset -v args
 args=(
     'https://acp.yseop-cloud.com/api/v1/platforms'
@@ -2049,6 +2051,7 @@ args=(
 )
 
 curl_fail_with_body "${args[@]}"
+----
 ====
 
 


### PR DESCRIPTION
J’allais parfois re-chercher ça dans des vieux projets, sans trop savoir quelle était la version la plus récente (et je l’ai encore un peu améliorée, là)…
NB : Le Gist est privé, pas indexé par moteurs de recherche et tout. Même si au fond rien de spécial dedans.