### PR TITLE
docs(java): save actions now natively exist in IJ

### DIFF
--- a/java/README.adoc
+++ b/java/README.adoc
@@ -184,21 +184,41 @@ You can also format a folder with a right click on this folder and btn:[Reformat
 
 To be sure not to forget to format your code, you can set “save actions”, a set of actions that will be triggered each time you save a modification in your code.
 
-* Install the `Save Actions` plugin.
+See if your IDE is recent enough to have menu:File[Settings > Tools > Actions on Save].
+If not, install the `Save Actions` plugin.
+Note that this plugin is not compatible with recent (about 2023) IntelliJ versions and may throw errors when saving.
 
-* Go to menu:File[Settings > Other settings > Save Actions].
+Proceed to <<save_actions_native>> or <<save_actions_plugin>> according to the case you are in.
 
-* Tick the 3 options in the “General” panel:
+
+[[save_actions_native]]
+==== With the IDE’s native save actions
+
+. Go to menu:File[Settings > Tools > Actions on Save].
+
+. Tick:
+** [x] btn:[Reformat code],
+** [x] btn:[Optimize imports].
+
+. Click btn:[OK].
+
+
+[[save_actions_plugin]]
+==== With the old third-party plugin
+
+. Go to menu:File[Settings > Other settings > Save Actions].
+
+. Tick the 3 options in the “General” panel:
 ** [x] btn:[Activate save actions on save],
 ** [x] btn:[Activite save actions on shortcut],
 ** [x] btn:[No action if compile errors].
 
-* Then tick the btn:[Optimize imports] box, and the btn:[Reformat file] box.
+. Then tick the btn:[Optimize imports] box, and the btn:[Reformat file] box.
 
-* Then tick the boxes:
+. Then tick the boxes:
 ** [x] btn:[Add missing @Override annotations],
 ** [x] btn:[Add blocks to if/while/for statements],
 ** [x] btn:[Remove explicit generic type for diamond]
 ** [x] and btn:[Remove unnecessary semicolon] boxes.
 
-* Click btn:[OK].
+. Click btn:[OK].

--- a/java/README.adoc
+++ b/java/README.adoc
@@ -1,12 +1,6 @@
 = Yseop code style documentation
-
 :experimental:
-:toc2:
-:sectnums:
-:revnumber: 1.0
-:icons: font
-:source-highlighter: coderay
-:sectanchors:
+:toc:
 :imagesdir: readme-img
 
 This document's goal is to show how to enforce the Yseop code Style (based on http://google.github.io/styleguide/javaguide.html[Google's guidelines]).
@@ -14,10 +8,10 @@ This document's goal is to show how to enforce the Yseop code Style (based on ht
 
 == Introduction
 
-Developers at Yseop can choose their preferred IDE among: 
+Developers at Yseop can choose their preferred IDE among:
 
-* Eclipse (most common use), 
-* IntelliJ (most recently used), 
+* Eclipse (most common use),
+* IntelliJ (most recently used),
 * and maybe others.
 
 In order to avoid code changes (and merge conflicts or whatever) when developers work with different IDEs on the same project, we have to find a common code Formatter configuration.

--- a/java/README.adoc
+++ b/java/README.adoc
@@ -189,6 +189,12 @@ Proceed to <<save_actions_native>> or <<save_actions_plugin>> according to the c
 ==== With the IDE’s native save actions
 
 . Go to menu:File[Settings > Tools > Actions on Save].
++
+[CAUTION]
+====
+This is project-specific.
+To change the default values, go through menu:File[New Projects Setup > Settings for new projects…] instead.
+====
 
 . Tick:
 ** [x] btn:[Reformat code],

--- a/java/README.adoc
+++ b/java/README.adoc
@@ -181,6 +181,7 @@ To be sure not to forget to format your code, you can set “save actions”, a 
 See if your IDE is recent enough to have menu:File[Settings > Tools > Actions on Save].
 If not, install the `Save Actions` plugin.
 Note that this plugin is not compatible with recent (about 2023) IntelliJ versions and may throw errors when saving.
+If you feel confident enough, you can try using a fork that better supports recent versions, like https://github.com/fishermans/intellij-plugin-save-actions[this one].
 
 Proceed to <<save_actions_native>> or <<save_actions_plugin>> according to the case you are in.
 


### PR DESCRIPTION
Suggestions are welcome as I’m just starting to use the native save actions right now. Not sure how you people configured it.
I did not see anything similar to the plugin’s “No action if compile errors” option, but perhaps that’s the default behavior?