### PR TITLE
docs(java): inspections to complete native IJ save actions

### DIFF
--- a/java/README.adoc
+++ b/java/README.adoc
@@ -189,17 +189,23 @@ Proceed to <<save_actions_native>> or <<save_actions_plugin>> according to the c
 [[save_actions_native]]
 ==== With the IDE’s native save actions
 
-. Go to menu:File[Settings > Tools > Actions on Save].
-+
 [CAUTION]
 ====
 This is project-specific.
-To change the default values, go through menu:File[New Projects Setup > Settings for new projects…] instead.
+To change the *default values*, go through menu:File[New Projects Setup > Settings for new projects…] instead of menu:File[Settings].
 ====
+
+. Go to menu:File[Settings > Tools > Actions on Save].
 
 . Tick:
 ** [x] btn:[Reformat code],
 ** [x] btn:[Optimize imports].
+
+. Still in settings, go to menu:Editor[Inspections], and focus on the Java ones (beware of similarly named inspections that exist for other supported languages):
+
+** [x] “Statement with empty body” Java inspection: tick btn:[Comments count as content].
+
+** [x] “Control flow statement without braces” Java inspection: increase the severity to “Error”.
 
 . Click btn:[OK].
 


### PR DESCRIPTION
* There’s stuff that used to be better handled when using the third-party plugin.
* And it’s weird to get yelled at for informative comments in if-else chains, especially when Sonar encourages us to end such chains with an extra else, even if it’s just to say “normal case, do nothing” or whatever.

Maybe this stuff about inspections could be placed in a dedicated section, I dunno. I doubt many people use a third-party save action thingy nowadays anyway.

Dunno if you guys have other remarks on some default IJ inspection settings that may not quite fit the company’s habits and style.