### PR TITLE
feat(java): switch “use_on_off_tags” to “true”

### DIFF
--- a/java/codeFormatter/Yseop_Code_Formatter.xml
+++ b/java/codeFormatter/Yseop_Code_Formatter.xml
@@ -75,7 +75,7 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.comment.align_tags_descriptions_grouped" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="130"/>
-<setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="true"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation" value="do not insert"/>


### PR DESCRIPTION
Otherwise `@formatter:off` and `@formatter:on` have no effect.
https://github.com/krasa/EclipseCodeFormatter/issues/64#issuecomment-141063956

This is merely a proposal. I suppose that we disabled this because it could be too tempting and lead to chaotically formatted code in some places. It could, however, come in handy in some edge cases:

* https://yseop.slack.com/archives/CP2AU2KNE/p1733302687445999 (the discussion after which I realized that we could not use those tags)
* https://github.com/yseop/aa_cloud-platform/blob/76ebfec534bdae743a7d7cb6f4c161c893dfc179/src/main/java/com/yseop/aa/cloudplatform/model/automationpack/VersionMatchingDataDto.java#L34

Of course, we would have to assume that the devs are careful enough not to suddenly, in the affected lines, go in full “YOLO mode” and start writing `@Tag   (   foo="plop"  )` instead of `@Tag(foo = "plop")` or whatever.

Dunno what everyone thinks of this. Feel free to add reviewers if you think anyone would be interested in this topic.